### PR TITLE
Fix occasional hang at end of NIS server stream.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ impl APCAccess {
       let data = String::from_utf8_lossy(&buffer[..bytes_read]);
       output.push_str(&data);
 
-      if data.ends_with(EOF) {
+      if output.ends_with(EOF) {
         stream.shutdown(std::net::Shutdown::Both)?;
         break;
       }


### PR DESCRIPTION
If the loop is reading fast enough, the buffer will always be near empty on each iteration. This can cause the EOF sequence to be split across multiple iterations of the loop, causing it to go undetected. To fix this we instead check the full output, instead of just the data that was read on the current loop iteration.