### PR TITLE
Change timeout to Duration, respect timeout when reading.

### DIFF
--- a/examples/example.rs
+++ b/examples/example.rs
@@ -1,3 +1,4 @@
+use std::time::Duration;
 use apcaccess::{APCAccess, APCAccessConfig};
 
 pub fn main() {
@@ -5,7 +6,7 @@ pub fn main() {
     host: "127.0.0.1".into(),
     port: 3551,
     strip_units: true,
-    timeout: 5,
+    timeout: Duration::from_secs(5),
   }));
 
   let data = apc.fetch().unwrap();


### PR DESCRIPTION
The timeout was previously only being checked after each read, but the read itself didn't respect the timeout, leading to some executions taking 15 seconds on my system despite a 1 second timeout.
This additionally changes the timeout error from a custom error to the standard WouldBlock error that the TcpStream returns when reading.
It's also more conventional to have timeouts use Duration, and it allows configuring a timeout less than one second.